### PR TITLE
Implement player scale option, player position option

### DIFF
--- a/DredgeVR/Options/OptionsConfig.cs
+++ b/DredgeVR/Options/OptionsConfig.cs
@@ -1,8 +1,9 @@
 ﻿using Newtonsoft.Json;
+using UnityEngine;
 
 namespace DredgeVR.Options;
 
-[JsonObject]
+[JsonObject(MemberSerialization.OptIn)]
 public class OptionsConfig
 {
 	/// <summary>
@@ -94,4 +95,15 @@ public class OptionsConfig
 	/// </summary>
 	[JsonProperty]
 	public bool smoothRotation = false;
+
+	/// <summary>
+	/// Changes the size of the player in the game world
+	/// </summary>
+	[JsonProperty]
+	public float playerScale = 1f;
+
+	[JsonProperty]
+	public float[] playerPosition = new float[] { 0, 1.13f, -1.5f };
+
+	public Vector3 PlayerPosition => new(playerPosition[0], playerPosition[1], playerPosition[2]);
 }

--- a/DredgeVR/VRCamera/EyeCamera.cs
+++ b/DredgeVR/VRCamera/EyeCamera.cs
@@ -75,6 +75,7 @@ public class EyeCamera : MonoBehaviour
 
 		// Magic number that some reddit thread told me was right
 		var eyeDistance = 63 / 1000f; //mm
+		//eyeDistance *= VRCameraManager.Instance.playerScale;
 
 		transform.localPosition = left ? Vector3.left * eyeDistance / 2f : Vector3.right * eyeDistance / 2f;
 

--- a/DredgeVR/VRCamera/EyeCamera.cs
+++ b/DredgeVR/VRCamera/EyeCamera.cs
@@ -75,7 +75,6 @@ public class EyeCamera : MonoBehaviour
 
 		// Magic number that some reddit thread told me was right
 		var eyeDistance = 63 / 1000f; //mm
-		//eyeDistance *= VRCameraManager.Instance.playerScale;
 
 		transform.localPosition = left ? Vector3.left * eyeDistance / 2f : Vector3.right * eyeDistance / 2f;
 

--- a/DredgeVR/VRCamera/VRCameraManager.cs
+++ b/DredgeVR/VRCamera/VRCameraManager.cs
@@ -28,14 +28,10 @@ public class VRCameraManager : MonoBehaviour
 	public static Transform AnchorTransform { get; private set; }
 	private Transform _pivot, _rotationPivot, _root;
 
-	private float _gameAnchorYPosition = 0.8f;
-
 	public float minX = 0.5f;
 	private bool _justTurned;
 
 	private bool _inFinaleCutscene;
-
-	public float playerScale = 0.3f;
 
 	public void Awake()
 	{
@@ -47,7 +43,7 @@ public class VRCameraManager : MonoBehaviour
 		leftCamera.transform.parent = transform;
 		leftCamera.transform.localPosition = Vector3.zero;
 		leftCamera.transform.localRotation = Quaternion.identity;
-		leftCamera.nearClipPlane *= playerScale;
+		leftCamera.nearClipPlane *= OptionsManager.Options.playerScale;
 		LeftEye = leftCamera.gameObject.AddComponent<EyeCamera>();
 		LeftEye.left = true;
 
@@ -55,7 +51,7 @@ public class VRCameraManager : MonoBehaviour
 		rightCamera.transform.parent = transform;
 		rightCamera.transform.localPosition = Vector3.zero;
 		rightCamera.transform.localRotation = Quaternion.identity;
-		rightCamera.nearClipPlane *= playerScale;
+		rightCamera.nearClipPlane *= OptionsManager.Options.playerScale;
 		RightEye = rightCamera.gameObject.AddComponent<EyeCamera>();
 		RightEye.left = false;
 
@@ -98,7 +94,7 @@ public class VRCameraManager : MonoBehaviour
 		dataLists.First().rendererFeatures.Insert(0, renderObject);
 
 		// Rescale the character
-		_pivot.transform.localScale = Vector3.one * playerScale;
+		_pivot.transform.localScale = Vector3.one * OptionsManager.Options.playerScale;
 	}
 
 	public void OnDestroy()
@@ -231,12 +227,14 @@ public class VRCameraManager : MonoBehaviour
 	{
 		if (_inFinaleCutscene) return;
 
-		AnchorTransform.localPosition = new Vector3(0, _gameAnchorYPosition + 0.33f, -1.5f);
+		AnchorTransform.localPosition = OptionsManager.Options.PlayerPosition;
 
 		// Helps when you ram into stuff to not bounce around
 		if (OptionsManager.Options.lockCameraYPosition)
 		{
-			AnchorTransform.position = new Vector3(AnchorTransform.position.x, _gameAnchorYPosition, AnchorTransform.position.z);
+			// Subtract 0.33 from the local height to go from local to global
+			var lockedY = OptionsManager.Options.PlayerPosition.y - 0.33f;
+			AnchorTransform.position = new Vector3(AnchorTransform.position.x, lockedY, AnchorTransform.position.z);
 		}
 	}
 

--- a/DredgeVR/VRCamera/VRCameraManager.cs
+++ b/DredgeVR/VRCamera/VRCameraManager.cs
@@ -35,6 +35,8 @@ public class VRCameraManager : MonoBehaviour
 
 	private bool _inFinaleCutscene;
 
+	public float playerScale = 0.3f;
+
 	public void Awake()
 	{
 		Instance = this;
@@ -45,6 +47,7 @@ public class VRCameraManager : MonoBehaviour
 		leftCamera.transform.parent = transform;
 		leftCamera.transform.localPosition = Vector3.zero;
 		leftCamera.transform.localRotation = Quaternion.identity;
+		leftCamera.nearClipPlane *= playerScale;
 		LeftEye = leftCamera.gameObject.AddComponent<EyeCamera>();
 		LeftEye.left = true;
 
@@ -52,6 +55,7 @@ public class VRCameraManager : MonoBehaviour
 		rightCamera.transform.parent = transform;
 		rightCamera.transform.localPosition = Vector3.zero;
 		rightCamera.transform.localRotation = Quaternion.identity;
+		rightCamera.nearClipPlane *= playerScale;
 		RightEye = rightCamera.gameObject.AddComponent<EyeCamera>();
 		RightEye.left = false;
 
@@ -92,6 +96,9 @@ public class VRCameraManager : MonoBehaviour
 		var renderObject = new RenderObjects { name = "Flip" };
 		Delay.FireOnNextUpdate(() => renderObject.GetValue<RenderObjectsPass>("renderObjectsPass").renderPassEvent = RenderPassEvent.AfterRendering);
 		dataLists.First().rendererFeatures.Insert(0, renderObject);
+
+		// Rescale the character
+		_pivot.transform.localScale = Vector3.one * playerScale;
 	}
 
 	public void OnDestroy()

--- a/DredgeVR/VRInput/VRHand.cs
+++ b/DredgeVR/VRInput/VRHand.cs
@@ -1,4 +1,5 @@
 ﻿using DredgeVR.Helpers;
+using DredgeVR.VRCamera;
 using System.Collections;
 using UnityAsyncAwaitUtil;
 using UnityEngine;
@@ -38,7 +39,7 @@ public class VRHand : MonoBehaviour
 		LaserPointerEnd = GameObject.CreatePrimitive(PrimitiveType.Sphere);
 		Component.DestroyImmediate(LaserPointerEnd.GetComponent<SphereCollider>());
 		LaserPointerEnd.transform.parent = RaycastCamera.transform;
-		LaserPointerEnd.transform.localScale = Vector3.one * 0.025f;
+		LaserPointerEnd.transform.localScale = Vector3.one * 0.025f * VRCameraManager.Instance.playerScale;
 		LaserPointerEnd.name = "Dot";
 
 		// Tried using a line renderer for this but it did not behave in VR
@@ -110,7 +111,7 @@ public class VRHand : MonoBehaviour
 
 			IsHoveringUI = inputRaycastDistance > 0;
 
-			var targetLength = IsHoveringUI ? inputRaycastDistance : defaultLength;
+			var targetLength = IsHoveringUI ? inputRaycastDistance : defaultLength * VRCameraManager.Instance.playerScale;
 
 			// Only collide with UI
 			var endPosition = RaycastCamera.transform.position + RaycastCamera.transform.forward * targetLength;
@@ -118,14 +119,16 @@ public class VRHand : MonoBehaviour
 			if (IsHoveringUI)
 			{
 				_line.transform.position = (transform.position + endPosition) / 2f;
-				_line.transform.localScale = new Vector3(0.005f, (transform.position - endPosition).magnitude / 2f, 0.005f);
+				var width = 0.005f * VRCameraManager.Instance.playerScale;
+				_line.transform.localScale = new Vector3(width, (transform.position - endPosition).magnitude / 2f, width);
 
 				LaserPointerEnd.transform.position = endPosition;
 			}
 			else
 			{
 				_fadedLine.transform.position = (transform.position + endPosition) / 2f;
-				_fadedLine.transform.localScale = new Vector3(0.001f, (transform.position - endPosition).magnitude / 2f, 0.001f);
+				var width = 0.001f * VRCameraManager.Instance.playerScale;
+				_fadedLine.transform.localScale = new Vector3(width, (transform.position - endPosition).magnitude / 2f, width);
 			}
 
 			// Should show when colliding with UI

--- a/DredgeVR/VRInput/VRHand.cs
+++ b/DredgeVR/VRInput/VRHand.cs
@@ -1,5 +1,7 @@
 ﻿using DredgeVR.Helpers;
+using DredgeVR.Options;
 using DredgeVR.VRCamera;
+using DredgeVR.VRUI;
 using System.Collections;
 using UnityAsyncAwaitUtil;
 using UnityEngine;
@@ -39,7 +41,7 @@ public class VRHand : MonoBehaviour
 		LaserPointerEnd = GameObject.CreatePrimitive(PrimitiveType.Sphere);
 		Component.DestroyImmediate(LaserPointerEnd.GetComponent<SphereCollider>());
 		LaserPointerEnd.transform.parent = RaycastCamera.transform;
-		LaserPointerEnd.transform.localScale = Vector3.one * 0.025f * VRCameraManager.Instance.playerScale;
+		LaserPointerEnd.transform.localScale = Vector3.one * 0.025f * OptionsManager.Options.playerScale;
 		LaserPointerEnd.name = "Dot";
 
 		// Tried using a line renderer for this but it did not behave in VR
@@ -59,6 +61,13 @@ public class VRHand : MonoBehaviour
 
 		VRInputModule.Instance.DominantHandChanged += OnDominantHandChanged;
 		OnDominantHandChanged(VRInputModule.Instance.DominantHandInputSource);
+
+		VRUIManager.HeldUIHidden += OnHeldUIHidden;
+	}
+
+	private void OnHeldUIHidden(bool hidden)
+	{
+
 	}
 
 	private void OnDominantHandChanged(SteamVR_Input_Sources dominantHand)
@@ -111,7 +120,7 @@ public class VRHand : MonoBehaviour
 
 			IsHoveringUI = inputRaycastDistance > 0;
 
-			var targetLength = IsHoveringUI ? inputRaycastDistance : defaultLength * VRCameraManager.Instance.playerScale;
+			var targetLength = IsHoveringUI ? inputRaycastDistance : defaultLength * OptionsManager.Options.playerScale;
 
 			// Only collide with UI
 			var endPosition = RaycastCamera.transform.position + RaycastCamera.transform.forward * targetLength;
@@ -119,7 +128,7 @@ public class VRHand : MonoBehaviour
 			if (IsHoveringUI)
 			{
 				_line.transform.position = (transform.position + endPosition) / 2f;
-				var width = 0.005f * VRCameraManager.Instance.playerScale;
+				var width = 0.005f * OptionsManager.Options.playerScale;
 				_line.transform.localScale = new Vector3(width, (transform.position - endPosition).magnitude / 2f, width);
 
 				LaserPointerEnd.transform.position = endPosition;
@@ -127,7 +136,7 @@ public class VRHand : MonoBehaviour
 			else
 			{
 				_fadedLine.transform.position = (transform.position + endPosition) / 2f;
-				var width = 0.001f * VRCameraManager.Instance.playerScale;
+				var width = 0.001f * OptionsManager.Options.playerScale;
 				_fadedLine.transform.localScale = new Vector3(width, (transform.position - endPosition).magnitude / 2f, width);
 			}
 

--- a/DredgeVR/VRUI/GameCanvasFixer.cs
+++ b/DredgeVR/VRUI/GameCanvasFixer.cs
@@ -18,9 +18,9 @@ internal class GameCanvasFixer : MonoBehaviour
 
 		if (uiParent != null)
 		{
-			transform.position = uiParent.transform.TransformPoint(Offset);
+			transform.position = uiParent.transform.TransformPoint(Offset * VRCameraManager.Instance.playerScale);
 			transform.rotation = Quaternion.Euler(0f, uiParent.rotation.eulerAngles.y, 0f);
-			transform.localScale = Vector3.one * scale;
+			transform.localScale = Vector3.one * scale * VRCameraManager.Instance.playerScale;
 		}
 	}
 }

--- a/DredgeVR/VRUI/GameCanvasFixer.cs
+++ b/DredgeVR/VRUI/GameCanvasFixer.cs
@@ -1,4 +1,5 @@
-﻿using DredgeVR.VRCamera;
+﻿using DredgeVR.Options;
+using DredgeVR.VRCamera;
 using UnityEngine;
 
 namespace DredgeVR.VRUI;
@@ -18,9 +19,9 @@ internal class GameCanvasFixer : MonoBehaviour
 
 		if (uiParent != null)
 		{
-			transform.position = uiParent.transform.TransformPoint(Offset * VRCameraManager.Instance.playerScale);
+			transform.position = uiParent.transform.TransformPoint(Offset * OptionsManager.Options.playerScale);
 			transform.rotation = Quaternion.Euler(0f, uiParent.rotation.eulerAngles.y, 0f);
-			transform.localScale = Vector3.one * scale * VRCameraManager.Instance.playerScale;
+			transform.localScale = Vector3.one * scale * OptionsManager.Options.playerScale;
 		}
 	}
 }

--- a/DredgeVR/VRUI/Patches/DestinationButtonPatches.cs
+++ b/DredgeVR/VRUI/Patches/DestinationButtonPatches.cs
@@ -1,5 +1,6 @@
 ﻿using Cinemachine.Utility;
 using DredgeVR.Helpers;
+using DredgeVR.Options;
 using HarmonyLib;
 using UnityEngine;
 
@@ -74,6 +75,12 @@ public static class DestinationButtonPatches
 		else if (__instance.destination.name == "Cave")
 		{
 			planeOffset *= 3f;
+		}
+
+		if (OptionsManager.Options.playerScale > 1)
+		{
+			yOffset *= OptionsManager.Options.playerScale;
+			scaleModifier /= OptionsManager.Options.playerScale;
 		}
 
 		__instance.transform.position = __instance.destination.transform.position + yOffset + planeOffset;

--- a/DredgeVR/VRUI/VRUIManager.cs
+++ b/DredgeVR/VRUI/VRUIManager.cs
@@ -1,5 +1,7 @@
 ﻿using DredgeVR.Helpers;
 using DredgeVR.Items;
+using DredgeVR.Options;
+using DredgeVR.VRCamera;
 using DredgeVR.VRInput;
 using System;
 using System.Linq;
@@ -137,7 +139,12 @@ internal class VRUIManager : MonoBehaviour
 				canvas.transform.rotation = Quaternion.Euler(0, 70, 0);
 			}
 
-			canvas.transform.localScale = Vector3.one * 0.002f;
+			canvas.transform.localScale = Vector3.one * 0.002f * OptionsManager.Options.playerScale;
+
+			// Tweak start canvas position based on player scale
+			var offset = (canvas.transform.position - VRCameraManager.AnchorTransform.position);
+			offset.y = 0;
+			canvas.transform.position += offset * (OptionsManager.Options.playerScale - 1f);
 
 			// Remove controls tab for now since it doesnt work
 			RemoveControlsTab(GameObject.Find("Canvases/SettingsDialog/TabbedPanelContainer").GetComponent<TabbedPanelContainer>());

--- a/DredgeVR/mod_meta.json
+++ b/DredgeVR/mod_meta.json
@@ -1,7 +1,7 @@
 {
 	"Name": "DredgeVR",
 	"ModGUID": "xen.DredgeVR",
-	"Version": "0.3.2",
+	"Version": "0.3.3",
 	"ModAssembly": "DredgeVR.dll",
 	"MinWinchVersion": "0.3.0",
 	"Entrypoint": "DredgeVR.Loader/Initialize",


### PR DESCRIPTION
Resize the player and pick where they stand on the boat

- [x] Rescale the player
- [x] Rescale all UI (need to work on main menu)
- [x] Allow changing boat anchor offset position

Might also want to implement an in-game options menu at the same time. Could be part of Winch instead.
If so, would need to go through all options and make sure that they actually update when changed in game (a lot of them are currently based on it being one unchanging value when the options file first loads).

Implements #56 